### PR TITLE
Add API key setter to UI

### DIFF
--- a/src/core/tutor.py
+++ b/src/core/tutor.py
@@ -23,6 +23,16 @@ class EnglishTutor:
         # Critical initialization
         self.speaking_tutor = SpeakingTutor(self.openai_service, self)
         self.writing_tutor = WritingTutor(self.openai_service, self)
+
+    def set_api_key(self, api_key: str) -> str:
+        """Update the API key and reinitialize the OpenAI service."""
+        if not api_key:
+            return "API key cannot be empty"
+        self.openai_api_key = api_key
+        self.openai_service = OpenAIService(api_key=api_key, model=self.model)
+        self.speaking_tutor.openai_service = self.openai_service
+        self.writing_tutor.openai_service = self.openai_service
+        return "API key updated"
     
     def _setup(self) -> None:
         """Initialize configuration."""

--- a/ui/interfaces.py
+++ b/ui/interfaces.py
@@ -49,11 +49,19 @@ class GradioInterface:
             with gr.Sidebar():
                 gr.Image("./assets/sophia-ia.png", label="Sophia IA")
                 gr.Markdown("## English Tutor AI")
-                gr.Textbox(label="Api Key", value="")
-                gr.Dropdown(
-                    label="model", 
-                    choices=["gpt-4o-mini", "gpt-4o", "gpt-4.1-mini", "gpt-3.5-turbo"], 
-                    value="" # Default value for the dropdown
+                api_key_box = gr.Textbox(label="API Key", type="password")
+                set_key_btn = gr.Button("Set API Key")
+                api_key_status = gr.Markdown("")
+                model_dropdown = gr.Dropdown(
+                    label="model",
+                    choices=["gpt-4o-mini", "gpt-4o", "gpt-4.1-mini", "gpt-3.5-turbo"],
+                    value=""  # Default value for the dropdown
+                )
+
+                set_key_btn.click(
+                    fn=self.tutor.set_api_key,
+                    inputs=[api_key_box],
+                    outputs=[api_key_status]
                 )
 
             with gr.Tab("Speaking Skills"):


### PR DESCRIPTION
## Summary
- add `set_api_key` method in `EnglishTutor`
- expose textbox and button in sidebar to update key

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68496cadfd88832ab277ff2282570f36