### PR TITLE
Enable UI streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - **Avaliação por Nível**: Feedback personalizado baseado no seu nível de inglês (1-10)
 - **Interface Intuitiva**: Fácil de usar com suporte a gravação de áudio
 - **Feedback Construtivo**: Dicas práticas para melhorar cada aspecto do seu inglês
+- **Respostas em streaming**: visualize o texto sendo gerado em tempo real
 
 ## 🛠️ Tecnologias
 

--- a/tests/test_tutor_streaming.py
+++ b/tests/test_tutor_streaming.py
@@ -1,0 +1,18 @@
+import types
+from unittest.mock import MagicMock, patch
+from src.core.writing_tutor import WritingTutor
+
+class DummyParent:
+    def get_system_message(self, mode='writing', level=None):
+        return 'sys'
+
+def test_writing_tutor_process_input_streams():
+    service = MagicMock()
+    service.stream_chat_completion.return_value = iter(["Hello", " world"])
+    with patch("src.core.writing_tutor.talker"):
+        tutor = WritingTutor(service, DummyParent())
+        history = []
+        gen = tutor.process_input("My essay", history, level="B1")
+        outputs = list(gen)
+    assert outputs[0][0][-1]["content"] == "Hello"
+    assert outputs[-1][0][-1]["content"] == "Hello world"


### PR DESCRIPTION
## Summary
- stream responses token by token in `SpeakingTutor` and `WritingTutor`
- mention streaming capability in README
- add regression test for streaming

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cd9898ee4832a81a856586249ec50