### PR TITLE
Improve light mode and mobile responsiveness

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -7,6 +7,14 @@
   --border-radius: 12px;
 }
 
+@media (prefers-color-scheme: light) {
+  :root {
+    --background-color: #ffffff;
+    --surface-color: #f2f2f2;
+    --text-color: #16161a;
+  }
+}
+
 body,
 .gradio-container {
   background-color: var(--background-color);
@@ -39,7 +47,13 @@ body,
   border-radius: var(--border-radius);
   padding: 0.5rem 1rem;
   cursor: pointer;
-  width: 50%;
+  width: 100%;
+}
+
+@media (min-width: 768px) {
+  .gradio-button {
+    width: 50%;
+  }
 }
 
 .gradio-button:hover {
@@ -52,6 +66,7 @@ body,
   color: var(--text-color);
   border: 1px solid var(--primary-color);
   border-radius: var(--border-radius);
+  width: 100%;
 }
 
 .chatbot-container {
@@ -94,8 +109,15 @@ body,
 
 #writing-row {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  #writing-row {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
 }
 
 #essay-text,
@@ -111,30 +133,33 @@ body,
 
 /*dropbox-level-select*/
 
-#component-17 {
-  width: 50%;
+#component-17,
+#component-19,
+#component-20,
+#component-22,
+#component-8 {
+  width: 100%;
 }
-
-#component-19 {
-  width: 50%;
-}
-
-#component-22 {
-  width: 20%;
-}
-
-/*container-generate-topic-btn*/
-
-#component-20 {
-  width: 50%;
-}
-
-/*container-api_key*/
 
 #component-8 {
   flex-wrap: nowrap;
-  width: 25%;
   justify-content: center;
+}
+
+@media (min-width: 768px) {
+  #component-17,
+  #component-19,
+  #component-20 {
+    width: 50%;
+  }
+
+  #component-22 {
+    width: 20%;
+  }
+
+  #component-8 {
+    width: 25%;
+  }
 }
 
 /*all-containers*/
@@ -145,7 +170,12 @@ body,
 
 #component-25 {
   width: 100%;
-  min-width: 500px;
+}
+
+@media (min-width: 768px) {
+  #component-25 {
+    min-width: 500px;
+  }
 }
 
 /*title-side-bar-markdown*/

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -102,7 +102,7 @@ body,
   gap: 1rem;
 }
 
-@media (min-width: 768px) {
+@media (min-width: 760px) {
   #writing-row {
     flex-direction: row;
     flex-wrap: wrap;
@@ -111,9 +111,17 @@ body,
 
 #essay-text,
 #chatbot-writing {
-  flex: 1 1 200px;
-  width: min(400px, 100%);
+  flex: 1 1 100%;
+  width: 100%;
   min-width: 0;
+}
+
+@media (min-width: 760px) {
+  #essay-text,
+  #chatbot-writing {
+    flex: 1 1 0;
+    width: auto;
+  }
 }
 
 #writing-buttons {
@@ -121,14 +129,22 @@ body,
   flex-wrap: wrap;
   gap: 0.5rem;
   justify-content: center;
+  align-items: center;
 }
 
 #writing-buttons .gradio-button {
   flex: 1 1 calc(50% - 1rem);
-  max-width: 160px;
+  max-width: 140px;
 }
 
-@media (min-width: 768px) {
+@media (max-width: 480px) {
+  #writing-buttons .gradio-button {
+    flex: 1 1 100%;
+    max-width: none;
+  }
+}
+
+@media (min-width: 760px) {
   #writing-buttons .gradio-button {
     flex: 1 1 calc(25% - 1rem);
   }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -50,10 +50,10 @@ body,
   color: var(--body-text-color, #ffffff);
   border: none;
   border-radius: var(--border-radius);
-  padding: 0.4rem 0.75rem;
+  padding: 0.3rem 0.6rem;
   cursor: pointer;
   width: auto;
-  max-width: 200px;
+  max-width: 160px;
   margin: 0.25rem;
 }
 
@@ -126,10 +126,10 @@ body,
 
 @media (min-width: 760px) and (max-width: 1220px) {
   #essay-text {
-    flex: 2 1 60%;
+    flex: 3 1 65%;
   }
   #chatbot-writing {
-    flex: 1 1 40%;
+    flex: 2 1 35%;
   }
 }
 
@@ -143,7 +143,7 @@ body,
 
 #writing-buttons .gradio-button {
   flex: 1 1 calc(50% - 1rem);
-  max-width: 140px;
+  max-width: 120px;
 }
 
 @media (max-width: 480px) {
@@ -161,7 +161,7 @@ body,
 
 .form.svelte-633qhp {
   width: 100%;
-  min-width: 0;
+  min-width: 0 !important;
 }
 
 /*dropbox-level-select*/

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,24 +1,13 @@
 :root {
   --primary-color: #7f5af0;
   --secondary-color: #2cb67d;
-  --background-color: #16161a;
-  --surface-color: #242629;
-  --text-color: #fffffe;
   --border-radius: 12px;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    --background-color: #ffffff;
-    --surface-color: #f2f2f2;
-    --text-color: #16161a;
-  }
 }
 
 body,
 .gradio-container {
-  background-color: var(--background-color);
-  color: var(--text-color);
+  background-color: var(--background-fill-primary, #ffffff);
+  color: var(--body-text-color, #000000);
   font-family: "Helvetica Neue", Arial, sans-serif;
 }
 
@@ -28,7 +17,7 @@ body,
 }
 
 .container {
-  background-color: var(--surface-color);
+  background-color: var(--background-fill-secondary, #f7f7f7);
   border: 1px solid var(--primary-color);
   border-radius: var(--border-radius);
   padding: 1rem;
@@ -42,7 +31,7 @@ body,
 
 .gradio-button {
   background: var(--primary-color);
-  color: var(--text-color);
+  color: var(--body-text-color, #ffffff);
   border: none;
   border-radius: var(--border-radius);
   padding: 0.5rem 1rem;
@@ -62,15 +51,15 @@ body,
 
 .input-textbox,
 .dropdown-select {
-  background-color: var(--surface-color);
-  color: var(--text-color);
+  background-color: var(--background-fill-secondary, #ffffff);
+  color: var(--body-text-color, #000000);
   border: 1px solid var(--primary-color);
   border-radius: var(--border-radius);
   width: 100%;
 }
 
 .chatbot-container {
-  background-color: var(--surface-color);
+  background-color: var(--background-fill-secondary, #ffffff);
   border: 1px solid var(--primary-color);
   border-radius: var(--border-radius);
   padding: 0.5rem;
@@ -84,18 +73,6 @@ body,
   border: none;
 }
 
-.avatar-image img {
-  width: 100px;
-  max-width: 100%;
-  height: auto;
-  border-radius: 50%;
-  object-fit: cover;
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-/* Avatar image styling */
 .avatar-image img {
   width: 120px;
   max-width: 100%;

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -50,15 +50,11 @@ body,
   color: var(--body-text-color, #ffffff);
   border: none;
   border-radius: var(--border-radius);
-  padding: 0.5rem 1rem;
+  padding: 0.4rem 0.75rem;
   cursor: pointer;
-  width: 100%;
-}
-
-@media (min-width: 768px) {
-  .gradio-button {
-    width: 50%;
-  }
+  width: auto;
+  max-width: 200px;
+  margin: 0.25rem;
 }
 
 .gradio-button:hover {
@@ -128,12 +124,13 @@ body,
 }
 
 #writing-buttons .gradio-button {
-  width: 100%;
+  flex: 1 1 calc(50% - 1rem);
+  max-width: 160px;
 }
 
 @media (min-width: 768px) {
   #writing-buttons .gradio-button {
-    width: 24%;
+    flex: 1 1 calc(25% - 1rem);
   }
 }
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -11,6 +11,22 @@ body,
   font-family: "Helvetica Neue", Arial, sans-serif;
 }
 
+@media (prefers-color-scheme: light) {
+  body,
+  .gradio-container {
+    background-color: #fdfdfd;
+    color: #000;
+  }
+
+  .container,
+  .input-textbox,
+  .dropdown-select,
+  .chatbot-container {
+    background-color: #ffffff;
+    color: #000;
+  }
+}
+
 #main-container {
   max-width: 900px;
   margin: auto;
@@ -102,6 +118,23 @@ body,
   flex: 1 1 200px;
   width: min(400px, 100%);
   min-width: 0;
+}
+
+#writing-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
+}
+
+#writing-buttons .gradio-button {
+  width: 100%;
+}
+
+@media (min-width: 768px) {
+  #writing-buttons .gradio-button {
+    width: 24%;
+  }
 }
 
 .form svelte-633qhp {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -159,8 +159,9 @@ body,
   }
 }
 
-.form svelte-633qhp {
-  min-width: min(450px, 100%);
+.form.svelte-633qhp {
+  width: 100%;
+  min-width: 0;
 }
 
 /*dropbox-level-select*/

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -124,6 +124,15 @@ body,
   }
 }
 
+@media (min-width: 760px) and (max-width: 1220px) {
+  #essay-text {
+    flex: 2 1 60%;
+  }
+  #chatbot-writing {
+    flex: 1 1 40%;
+  }
+}
+
 #writing-buttons {
   display: flex;
   flex-wrap: wrap;

--- a/ui/interfaces.py
+++ b/ui/interfaces.py
@@ -126,25 +126,22 @@ class GradioInterface:
                             autoscroll=True,
                         )
 
-                    with gr.Row():
-                        with gr.Row():
-                            evaluate_essay_btn = gr.Button(
-                                "Evaluate My Essay",
-                                variant="primary",
-                                elem_classes="gradio-button",
-                                elem_id="evaluate-essay-btn",
-                            )
-                            clear_writing_btn = gr.Button(
-                                "Clear", elem_classes="gradio-button", elem_id="clear-essay-btn"
-                            )
-                        with gr.Column():
-                            with gr.Row():
-                                play_audio_btn = gr.Button(
-                                    "Play Audio", elem_classes="gradio-button", elem_id="play-audio-btn"
-                                )
-                                clear_chatbot_btn = gr.Button(
-                                    "Clear", elem_classes="gradio-button", elem_id="clear-chatbot-btn"
-                                )
+                    with gr.Row(elem_id="writing-buttons"):
+                        evaluate_essay_btn = gr.Button(
+                            "Evaluate My Essay",
+                            variant="primary",
+                            elem_classes="gradio-button",
+                            elem_id="evaluate-essay-btn",
+                        )
+                        clear_writing_btn = gr.Button(
+                            "Clear", elem_classes="gradio-button", elem_id="clear-essay-btn"
+                        )
+                        play_audio_btn = gr.Button(
+                            "Play Audio", elem_classes="gradio-button", elem_id="play-audio-btn"
+                        )
+                        clear_chatbot_btn = gr.Button(
+                            "Clear", elem_classes="gradio-button", elem_id="clear-chatbot-btn"
+                        )
 
                 generate_topic_btn.click(
                     fn=self.tutor.writing_tutor.generate_random_topic,


### PR DESCRIPTION
## Summary
- add `prefers-color-scheme` section for a clean light theme
- update button styling and input widths for mobile-first layouts
- make writing section responsive and adjust component widths

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for gradio and openai)*

------
https://chatgpt.com/codex/tasks/task_e_684f72bd22a4832a8186807c07aaaa7d