### PR TITLE
Delay displaying assistant text until audio plays

### DIFF
--- a/src/core/speaking_tutor.py
+++ b/src/core/speaking_tutor.py
@@ -140,7 +140,5 @@ class SpeakingTutor(BaseTutor):
         self, history: Optional[List[Dict[str, Any]]], level: Optional[str] = None
     ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
         """Wrapper to obtain bot response returning history and audio only."""
-        updated_history, _, bot_audio_path = self.handle_bot_response(
-            history=history, level=level
-        )
+        updated_history, _, bot_audio_path = self.handle_bot_response(history=history, level=level)
         return updated_history, bot_audio_path

--- a/src/core/speaking_tutor.py
+++ b/src/core/speaking_tutor.py
@@ -135,3 +135,12 @@ class SpeakingTutor(BaseTutor):
             f"handle_bot_response: Finished. History len: {len(current_history)}, Audio path: {bot_audio_path}"
         )
         return current_history, current_history, bot_audio_path
+
+    def handle_bot_response_audio_first(
+        self, history: Optional[List[Dict[str, Any]]], level: Optional[str] = None
+    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+        """Wrapper to obtain bot response returning history and audio only."""
+        updated_history, _, bot_audio_path = self.handle_bot_response(
+            history=history, level=level
+        )
+        return updated_history, bot_audio_path

--- a/ui/interfaces.py
+++ b/ui/interfaces.py
@@ -24,6 +24,14 @@ class GradioInterface:
         except ValueError as e:
             return gr.Error(str(e))
 
+    @staticmethod
+    def delay_history(history, seconds: float = 1.0):
+        """Return history after a short delay to show audio first."""
+        import time
+
+        time.sleep(seconds)
+        return history
+
     def create_interface(self):
         """Create and configure the Gradio interface."""
 
@@ -90,12 +98,17 @@ class GradioInterface:
                     inputs=[history_speaking, audio_input_mic, level],
                     outputs=[chatbot_speaking, history_speaking],
                 ).then(
-                    # 2. After transcription -> get bot response (updates history with text) and audio path
-                    fn=self.tutor.speaking_tutor.handle_bot_response,
+                    # 2. After transcription -> get bot response and audio path (history updated only)
+                    fn=self.tutor.speaking_tutor.handle_bot_response_audio_first,
                     inputs=[history_speaking, level],
-                    outputs=[chatbot_speaking, history_speaking, audio_output_speaking],
+                    outputs=[history_speaking, audio_output_speaking],
                 ).then(
-                    # 3. After bot responds -> clear the audio input component
+                    # 3. After audio starts playing -> delay a bit and show text
+                    fn=self.delay_history,
+                    inputs=[history_speaking],
+                    outputs=[chatbot_speaking],
+                ).then(
+                    # 4. Clear the audio input component
                     fn=lambda: None,
                     inputs=None,
                     outputs=[audio_input_mic],

--- a/ui/interfaces.py
+++ b/ui/interfaces.py
@@ -27,9 +27,15 @@ class GradioInterface:
     @staticmethod
     def delay_history(history, seconds: float = 1.0):
         """Return history after a short delay to show audio first."""
+        import logging
         import time
 
+        logger = logging.getLogger(__name__)
+        logger.info("delay_history: start waiting for %.2f seconds", seconds)
+        start = time.monotonic()
         time.sleep(seconds)
+        elapsed = time.monotonic() - start
+        logger.info("delay_history: finished waiting after %.2f seconds", elapsed)
         return history
 
     def create_interface(self):


### PR DESCRIPTION
## Summary
- allow delaying the speaking text output until audio is heard
- add helper method for delayed history output

## Testing
- `pytest tests/test_openai_service.py tests/test_min_gradio.py::test_echo -q`

------
https://chatgpt.com/codex/tasks/task_e_685846591908832abfaeef72a0c875bd