### PR TITLE
Improve Gradio UI

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -2,6 +2,7 @@
   --primary-color: #7f5af0;
   --secondary-color: #2cb67d;
   --border-radius: 12px;
+  --button-gradient: linear-gradient(135deg, #7f5af0 0%, #2cb67d 100%);
 }
 
 body,
@@ -30,7 +31,7 @@ body,
 }
 
 .gradio-button {
-  background: var(--primary-color);
+  background: var(--button-gradient);
   color: var(--body-text-color, #ffffff);
   border: none;
   border-radius: var(--border-radius);
@@ -39,10 +40,11 @@ body,
   width: auto;
   max-width: 160px;
   margin: 0.25rem;
+  transition: opacity 0.2s ease-in-out;
 }
 
 .gradio-button:hover {
-  background: #9a7dff;
+  opacity: 0.85;
 }
 
 .input-textbox,
@@ -223,4 +225,16 @@ body,
 #title {
   text-align: center;
   margin-bottom: 1rem;
+}
+
+#word-counter {
+  text-align: right;
+  font-size: 0.9rem;
+  color: var(--secondary-color);
+}
+
+#dashboard-placeholder {
+  color: var(--primary-color);
+  text-align: center;
+  padding: 1rem 0;
 }

--- a/ui/interfaces.py
+++ b/ui/interfaces.py
@@ -1,7 +1,4 @@
-import gradio as gr
 from pathlib import Path
-
-
 from typing import TYPE_CHECKING
 
 import gradio as gr
@@ -38,20 +35,35 @@ class GradioInterface:
 
             with gr.Sidebar():
                 gr.Image(
-                    "./assets/sophia-ia.png", label="English Tutor AI", elem_classes="avatar-image", container=False
+                    "./assets/sophia-ia.png",
+                    label="English Tutor AI",
+                    elem_classes="avatar-image",
+                    container=False,
                 )
 
                 gr.Markdown("## Sophia AI", elem_id="title")
 
-                api_key_box = gr.Textbox(
-                    label="API Key", type="password", elem_classes="input-textbox", elem_id="api-key"
-                )
-                with gr.Row():
-                    set_key_btn = gr.Button("Set", elem_classes="gradio-button", elem_id="set-key")
-                    clear_key_btn = gr.Button("Clear", elem_classes="gradio-button", elem_id="clear-key")
+                with gr.Accordion("Settings", open=True):
+                    api_key_box = gr.Textbox(
+                        label="API Key",
+                        type="password",
+                        elem_classes="input-textbox",
+                        elem_id="api-key",
+                    )
+                    with gr.Row():
+                        set_key_btn = gr.Button(
+                            "Set", elem_classes="gradio-button", elem_id="set-key"
+                        )
+                        clear_key_btn = gr.Button(
+                            "Clear", elem_classes="gradio-button", elem_id="clear-key"
+                        )
 
-                set_key_btn.click(fn=self.set_api_key_ui, inputs=[api_key_box], outputs=[api_key_box])
-                clear_key_btn.click(fn=lambda: None, inputs=None, outputs=[api_key_box])
+                    set_key_btn.click(
+                        fn=self.set_api_key_ui, inputs=[api_key_box], outputs=[api_key_box]
+                    )
+                    clear_key_btn.click(
+                        fn=lambda: None, inputs=None, outputs=[api_key_box]
+                    )
 
             with gr.Tab("Speaking Skills"):
                 # ... (chatbot, entry, mic components)
@@ -103,6 +115,13 @@ class GradioInterface:
                         elem_classes="dropdown-select",
                         elem_id="level-select",
                     )
+                    essay_type_dropdown = gr.Dropdown(
+                        label="Essay Type",
+                        choices=["Narrative", "Argumentative", "Informative"],
+                        value="Narrative",
+                        elem_classes="dropdown-select",
+                        elem_id="essay-type-select",
+                    )
                     # audio_output_writing = gr.Audio(visible=True, autoplay=False, elem_id="audio-output-writing")
 
                 with gr.Row(elem_id="writing-button-row"):
@@ -126,6 +145,10 @@ class GradioInterface:
                             elem_classes="input-textbox",
                             elem_id="essay-text",
                         )
+                        word_counter = gr.Markdown(
+                            "0 words",
+                            elem_id="word-counter",
+                        )
 
                         chatbot_writing = gr.Chatbot(
                             label="Writing Feedback",
@@ -147,23 +170,19 @@ class GradioInterface:
 
                 generate_topic_btn.click(
                     fn=self.tutor.writing_tutor.generate_random_topic,
-                    inputs=[
-                        level_dropdown_writing,
-                        history_writing,
-                    ],  # Pass dropdown value and history
-                    outputs=[
-                        chatbot_writing,
-                        history_writing,
-                    ],  # Topic appears in chatbot, history updated
+                    inputs=[level_dropdown_writing, history_writing, essay_type_dropdown],
+                    outputs=[chatbot_writing, history_writing],
                 )
 
                 evaluate_essay_btn.click(
                     fn=self.tutor.writing_tutor.process_input,
-                    inputs=[essay_input_text, history_writing, level_dropdown_writing],
-                    outputs=[
-                        chatbot_writing,
+                    inputs=[
+                        essay_input_text,
                         history_writing,
-                    ],  # Feedback in chatbot, history updated
+                        level_dropdown_writing,
+                        essay_type_dropdown,
+                    ],
+                    outputs=[chatbot_writing, history_writing],
                 )
                 play_audio_btn.click(
                     fn=self.tutor.writing_tutor.play_audio,
@@ -171,7 +190,20 @@ class GradioInterface:
                     outputs=[audio_output_writing],  # Output to the invisible audio component
                 )
 
+                essay_input_text.change(
+                    fn=lambda x: f"{len(x.split())} words" if x else "0 words",
+                    inputs=essay_input_text,
+                    outputs=word_counter,
+                )
+
                 clear_writing_btn.click(fn=lambda: None, inputs=None, outputs=[essay_input_text])
+
+            with gr.Tab("Dashboard"):
+                gr.Markdown("## Student Progress")
+                gr.Markdown(
+                    "This section will display your progress over time.",
+                    elem_id="dashboard-placeholder",
+                )
 
         return demo
 


### PR DESCRIPTION
## Summary
- redesign buttons with gradient styles
- add word counter and essay type dropdown to writing tab
- group API key field inside sidebar accordion
- add placeholder dashboard tab and minor CSS tweaks

## Testing
- `python -m py_compile ui/interfaces.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: AttributeError: module 'src.core.speaking_tutor' has no attribute 'play_audio')*

------
https://chatgpt.com/codex/tasks/task_e_686715e0758c832a9ea9bef29646abd8