### PR TITLE
Enhance gradio UI design

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -30,7 +30,7 @@ body,
 }
 
 .gradio-button {
-  background: var(--primary-color);
+  background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
   color: var(--body-text-color, #ffffff);
   border: none;
   border-radius: var(--border-radius);
@@ -39,10 +39,11 @@ body,
   width: auto;
   max-width: 160px;
   margin: 0.25rem;
+  transition: background 0.3s ease;
 }
 
 .gradio-button:hover {
-  background: #9a7dff;
+  background: linear-gradient(135deg, #9a7dff, #37dc9b);
 }
 
 .input-textbox,
@@ -223,4 +224,19 @@ body,
 #title {
   text-align: center;
   margin-bottom: 1rem;
+}
+
+/* Dashboard and word count styling */
+#dashboard-text {
+  text-align: center;
+  font-weight: bold;
+  margin-top: 1rem;
+}
+
+.word-count {
+  text-align: right;
+  font-size: 0.9rem;
+  color: var(--secondary-color);
+  margin-top: -0.5rem;
+  margin-bottom: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- update button styles with gradients and hover transition
- add dashboard tab and word counter in UI

## Testing
- `pytest -q` *(fails: play_audio and talker not found)*

------
https://chatgpt.com/codex/tasks/task_e_686715e0758c832a9ea9bef29646abd8