### PR TITLE
Add React demo with FastAPI server

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,18 @@ English-Tutor-AI/
 └── pyproject.toml         # Project dependencies (Poetry)
 ```
 
+## ⚛️ React Integration
+
+This repository also includes a minimal React frontend served via **FastAPI**.
+The `api/server.py` file mounts the Gradio interface and exposes REST endpoints
+used by the React app. To try it out:
+
+1. Install the additional dependencies: `pip install fastapi uvicorn`.
+2. Start the backend with `python api/server.py`.
+3. Inside the `frontend` folder run `npm install` and `npm run dev`.
+4. Open `http://localhost:5173` to use the React interface.
+
+
 ## 🔮 Future Roadmap & Vision
 
 Sophia AI is a strong foundation. Future enhancements could include:

--- a/api/server.py
+++ b/api/server.py
@@ -1,0 +1,68 @@
+from fastapi import FastAPI, UploadFile, File, Form
+from fastapi.middleware.cors import CORSMiddleware
+import gradio as gr
+
+from src.core.tutor import EnglishTutor
+from ui.interfaces import GradioInterface
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+tutor = EnglishTutor()
+interface = GradioInterface(tutor).create_interface()
+app = gr.mount_gradio_app(app, interface, path="/gradio")
+
+
+@app.post("/api/speech")
+async def process_speech(file: UploadFile = File(...), level: str = Form("B1")):
+    """Handle speaking practice: audio upload -> response text + audio."""
+    audio_path = f"/tmp/{file.filename}"
+    with open(audio_path, "wb") as out:
+        out.write(await file.read())
+
+    hist, _ = tutor.speaking_tutor.handle_transcription(history=[], audio_filepath=audio_path)
+    response_generator = tutor.speaking_tutor.handle_bot_response(history=hist, level=level)
+
+    final_history, audio_out = None, None
+    for hist_out, _, audio_path in response_generator:
+        final_history = hist_out
+        audio_out = audio_path
+    return {"history": final_history, "audio_path": audio_out}
+
+
+@app.post("/api/writing/evaluate")
+async def evaluate(essay: str = Form(...), level: str = Form("B1")):
+    """Evaluate an essay and return the conversation history."""
+    gen = tutor.writing_tutor.process_input(essay, [], level)
+    final_history = None
+    for hist, _ in gen:
+        final_history = hist
+    return {"history": final_history}
+
+
+@app.post("/api/writing/topic")
+async def generate_topic(level: str = Form("B1")):
+    """Generate a random writing topic."""
+    gen = tutor.writing_tutor.generate_random_topic(level=level, history=[])
+    final_history = None
+    for hist, _ in gen:
+        final_history = hist
+    return {"history": final_history}
+
+
+@app.get("/api/progress")
+def progress():
+    """Get current progress dashboard as HTML."""
+    return {"html": tutor.progress_tracker.html_dashboard()}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/environment.yml
+++ b/environment.yml
@@ -14,3 +14,5 @@ dependencies:
       - gradio==5.29.0
       - gradio-client==1.10.0
       - pre-commit
+      - fastapi
+      - uvicorn

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sophia AI React</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "sophia-react",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+
+export default function App() {
+  const [essay, setEssay] = useState('');
+  const [writingHistory, setWritingHistory] = useState([]);
+  const [topic, setTopic] = useState('');
+  const [audioUrl, setAudioUrl] = useState('');
+
+  async function handleEvaluate() {
+    const formData = new FormData();
+    formData.append('essay', essay);
+    formData.append('level', 'B1');
+    const res = await fetch('/api/writing/evaluate', {
+      method: 'POST',
+      body: formData
+    });
+    const data = await res.json();
+    setWritingHistory(data.history);
+  }
+
+  async function handleTopic() {
+    const formData = new FormData();
+    formData.append('level', 'B1');
+    const res = await fetch('/api/writing/topic', {
+      method: 'POST',
+      body: formData
+    });
+    const data = await res.json();
+    setTopic(data.history[data.history.length - 1].content);
+  }
+
+  async function handleAudio(e) {
+    const file = e.target.files[0];
+    if (!file) return;
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('level', 'B1');
+    const res = await fetch('/api/speech', { method: 'POST', body: formData });
+    const data = await res.json();
+    setAudioUrl(data.audio_path);
+  }
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>Sophia AI React</h1>
+      <section>
+        <h2>Writing</h2>
+        <textarea
+          rows={10}
+          value={essay}
+          onChange={e => setEssay(e.target.value)}
+          placeholder="Write your essay"
+        />
+        <div>
+          <button onClick={handleEvaluate}>Evaluate</button>
+          <button onClick={handleTopic}>Random Topic</button>
+        </div>
+        <pre>{JSON.stringify(writingHistory, null, 2)}</pre>
+        {topic && <p><strong>Topic:</strong> {topic}</p>}
+      </section>
+      <section>
+        <h2>Speaking</h2>
+        <input type="file" accept="audio/*" onChange={handleAudio} />
+        {audioUrl && <audio src={audioUrl} controls />}        
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000'
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- expose a FastAPI server at `api/server.py` that mounts the Gradio app and provides REST endpoints
- include a minimal React client under `frontend/`
- add FastAPI dependencies to `environment.yml`
- document the React integration in README

## Testing
- `pytest -q` *(fails: AttributeError: <module 'src.core.speaking_tutor' ...>)*

------
https://chatgpt.com/codex/tasks/task_e_687cfed09ba4832aafa3b32adf54e0fe