### PR TITLE
Fix hybrid mode chatbot streaming placeholder

### DIFF
--- a/front_end/components/SpeakingTab.tsx
+++ b/front_end/components/SpeakingTab.tsx
@@ -672,11 +672,11 @@ const SpeakingTab: React.FC<SpeakingTabProps> = ({ englishLevel }) => {
                 m.role === "assistant" &&
                 (typeof m.content === "string" || (m as any).text_for_llm)
             );
-              const needsAssistantPlaceholder =
-                awaitingAssistantRef.current || isLoading;
-              if (needsAssistantPlaceholder && !lastIsAssistantPending) {
-                merged = [...merged, { role: "assistant", content: null }];
-              }
+            const needsAssistantPlaceholder =
+              awaitingAssistantRef.current && !hasAssistantText;
+            if (needsAssistantPlaceholder && !lastIsAssistantPending) {
+              merged = [...merged, { role: "assistant", content: null }];
+            }
             // Stop awaiting only once assistant textual content appears
             awaitingAssistantRef.current = !hasAssistantText;
 

--- a/front_end/components/SpeakingTab.tsx
+++ b/front_end/components/SpeakingTab.tsx
@@ -672,14 +672,11 @@ const SpeakingTab: React.FC<SpeakingTabProps> = ({ englishLevel }) => {
                 m.role === "assistant" &&
                 (typeof m.content === "string" || (m as any).text_for_llm)
             );
-            const needsAssistantPlaceholder =
-              awaitingAssistantRef.current ||
-              !!audioUrl ||
-              isLoading ||
-              botSpeaking;
-            if (needsAssistantPlaceholder && !lastIsAssistantPending) {
-              merged = [...merged, { role: "assistant", content: null }];
-            }
+              const needsAssistantPlaceholder =
+                awaitingAssistantRef.current || isLoading;
+              if (needsAssistantPlaceholder && !lastIsAssistantPending) {
+                merged = [...merged, { role: "assistant", content: null }];
+              }
             // Stop awaiting only once assistant textual content appears
             awaitingAssistantRef.current = !hasAssistantText;
 

--- a/front_end/components/__tests__/assistant-has-text.test.tsx
+++ b/front_end/components/__tests__/assistant-has-text.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { __TEST_ONLY__ } from '../SpeakingTab';
+import type { ChatMessage } from '../../types';
+
+describe('assistantHasText', () => {
+  const fn = __TEST_ONLY__.assistantHasText!;
+
+  it('detects plain string content', () => {
+    const msgs: ChatMessage[] = [{ role: 'assistant', content: 'hello' }];
+    expect(fn(msgs)).toBe(true);
+  });
+
+  it('detects text inside content.text', () => {
+    const msgs: ChatMessage[] = [{ role: 'assistant', content: { text: 'hi' } as any }];
+    expect(fn(msgs)).toBe(true);
+  });
+
+  it('detects text_for_llm field', () => {
+    const msgs: ChatMessage[] = [{ role: 'assistant', content: null, text_for_llm: 'hey' }];
+    expect(fn(msgs)).toBe(true);
+  });
+
+  it('returns false when no text is present', () => {
+    const msgs: ChatMessage[] = [{ role: 'assistant', content: null }];
+    expect(fn(msgs)).toBe(false);
+  });
+});

--- a/front_end/components/__tests__/chatbot-get-message-text.test.tsx
+++ b/front_end/components/__tests__/chatbot-get-message-text.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { __TEST_ONLY__ } from '../Chatbot';
+import type { ChatMessage } from '../../types';
+
+describe('getMessageText', () => {
+  const fn = __TEST_ONLY__.getMessageText!;
+
+  it('returns string content directly', () => {
+    const msg: ChatMessage = { role: 'assistant', content: 'hello' };
+    expect(fn(msg)).toBe('hello');
+  });
+
+  it('extracts text from nested content.text', () => {
+    const msg: ChatMessage = { role: 'assistant', content: { text: 'hi' } as any };
+    expect(fn(msg)).toBe('hi');
+  });
+
+  it('falls back to text_for_llm field', () => {
+    const msg: ChatMessage = { role: 'assistant', content: null, text_for_llm: 'hey' };
+    expect(fn(msg)).toBe('hey');
+  });
+
+  it('returns null when no text is present', () => {
+    const msg: ChatMessage = { role: 'assistant', content: null };
+    expect(fn(msg)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- avoid adding extra assistant placeholder when hybrid streaming text is present

## Testing
- `pre-commit run --files front_end/components/SpeakingTab.tsx`
- `cd front_end && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac4e1f08f0832aaaf10e9153514923